### PR TITLE
Fix initialization of blank group; Population of leaders for empty group

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -57,7 +57,7 @@ client.on('message', message => {
 	}
 
 	if (message.content === `${prefix}groups`) {
-		groups[0] = groups[0] || pool
+		groups[0] = groups[0] || (pool.length > 0 ? pool : leaders)
 		const waitlistGroup = formatGroupMessage(waitlist)
 		const differenceMsg = formatDifferenceMessage(computeDifference(true))
 
@@ -194,8 +194,6 @@ function formatDifferenceMessage(difference){
 }
 
 function balance(pool, message){
-	groups[0] = [];
-	groups[1] = [];
 	if (pool.length <= 8){
 		groups[0] = [leaders[0], leaders[1], ...pool]
 	} else {


### PR DESCRIPTION
- Empty group was appearing due to initialization of empty second group in balance
- Set default group to leaders if nobody checked in