### PR TITLE
Added CPB group logic and message to !groups command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -74,8 +74,7 @@ client.on('message', message => {
 		if (chaosPinkBeanGroup && chaosPinkBeanGroup.length){
 			msg += `\nChaos Pink Bean Group: ${formatGroupMessage(chaosPinkBeanGroup)} (${totalRank(chaosPinkBeanGroup)})`
 		}
-		console.log(msg.join("\n"))
-		message.channel.send("```" + msg.join("\n") + "```")
+		message.channel.send("```" + msg + "```")
 		if(groups.length > 1) message.channel.send(`\`${differenceMsg}\``)
 	}
 
@@ -206,7 +205,7 @@ function balance(pool, message){
 		poolToJoin = poolToJoin.concat(leftover)
 
 		while(poolToJoin.length){
-			let diff = computeDifference(false)
+			let diff = computeDifference(g0, g1, false)
 			var max = poolToJoin.sort((a,b) => b.rank-a.rank)[0].rank
 			const memberToJoin = poolToJoin.find(member => member.rank === max)
 			if(g0.length === 1 && g1.length === 1){
@@ -239,10 +238,9 @@ function totalRank(group){
 	return group.reduce(function (acc, obj) { return acc + obj.rank; }, 0);
 }
 
-function computeDifference(abs){
-	let totalRanks = groups.map(group => totalRank(group))
-	const g1 = Math.max(...totalRanks);
-	const g2 = Math.min(...totalRanks);
+function computeDifference(group1, group2, abs){
+	const g1 = group1 && totalRank(group1)
+	const g2 = group2 && totalRank(group2)
 	return abs ? Math.abs(g1-g2) : (g1-g2)
 }
 
@@ -316,6 +314,9 @@ var expoTimer = new CronJob('30 17 * * *', function(){
 			for(var i = 0; i < timerChannels.length; i++){
 				var channel = client.channels.get(timerChannels[i]);
 				if(channel != undefined){
+					pool = [];
+					groups = [];
+					waitlist = [];
 					channel.send(expoMsg);
 				}
 			}

--- a/commands/swap.js
+++ b/commands/swap.js
@@ -1,0 +1,31 @@
+var fs = require("fs");
+
+module.exports = {
+  swap: function (message, groups) {
+    message.channel.send("Zakum used **Swap!**")
+    let params = message.content.split(" ")
+    if(!(groups.length > 1) || params.length !== 3){
+       message.channel.send("*But nothing happened!*")
+      return;
+    }
+    const first = params[1]
+    const second = params[2]
+    let swapGroups = []
+    groups.forEach((group, index) => {
+      const p1 = group.find(member => member.name.toLowerCase() === first.toLowerCase())
+      const p2 = group.find(member => member.name.toLowerCase() === second.toLowerCase())
+      p1 && swapGroups.push({groupId: index, member:p1})
+      p2 && swapGroups.push({groupId: index, member:p2})
+    })
+    if (swapGroups.length < 2 || swapGroups[0].groupId === swapGroups[1].groupId) {
+      message.channel.send("*The attack missed!*")
+      return;
+    }
+    groups[swapGroups[0].groupId] = groups[swapGroups[0].groupId].filter(member => member.name.toLowerCase() !== swapGroups[0].member.name.toLowerCase())
+    groups[swapGroups[1].groupId] = groups[swapGroups[1].groupId].filter(member => member.name.toLowerCase() !== swapGroups[1].member.name.toLowerCase())
+    groups[swapGroups[0].groupId].push(swapGroups[1].member)
+    groups[swapGroups[1].groupId].push(swapGroups[0].member)
+    message.channel.send("*It was super effective!*")
+
+  }
+};


### PR DESCRIPTION
Changes:
- Logic for printing CPB group which is the top 10 overall DPS + a Bishop if the top 10 doesn't contain a bishop
- Changed group length in group message to group strength 
- Refactored and cleaned shit up 
- Reverted commits that broke group balancing

Multiple groups:
![image](https://user-images.githubusercontent.com/9439128/62677123-cbe98580-b972-11e9-8e7d-4a7a599dd084.png)

Only leaders:
![image](https://user-images.githubusercontent.com/9439128/62677137-db68ce80-b972-11e9-95fb-c42eafb73cb9.png)

One group:
![image](https://user-images.githubusercontent.com/9439128/62677149-e4f23680-b972-11e9-8ca1-24150356b119.png)

