### PR TITLE
Unit tests for demote and some formatting

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -104,7 +104,7 @@ client.on('message', message => {
 	if (message.content.substring(0,7) === `${prefix}demote` && isAdmin) {
 		const name = message.content.split(" ")[1]
 		let roster = getRoster()
-		demote(message, roster, leaders, name);
+		demote(message, roster);
 	}
 
 	if(message.content.substring(0,6) === `${prefix}class`){

--- a/commands/add.js
+++ b/commands/add.js
@@ -20,11 +20,11 @@ module.exports = {
     console.log(roster)
 
     fs.writeFile(rosterLoc, JSON.stringify({"lt3":roster}, null, 4), (err) => {
-    if (err) {
-        console.error(err);
-        return;
-    };
-    message.channel.send(`Successfully added ${member.name} to the LessThan3 guild roster!`)
+      if (err) {
+          console.error(err);
+          return;
+      };
+      message.channel.send(`Successfully added ${member.name} to the LessThan3 guild roster!`)
     });
   }
 };

--- a/commands/demote.js
+++ b/commands/demote.js
@@ -1,25 +1,24 @@
 var fs = require("fs");
 
 module.exports = {
-  demoteCommand: function (message, roster, leaders, name) {
+  demoteCommand: function (message, roster, rosterLoc = "./guilds/lt3.json") {
     if(message.content.split(" ").length !== 2) {
       message.channel.send("No input. Please use like so: !demote <IGN>")
       return;
     }
-
+    const name = message.content.split(" ")[1];
     let demoted = roster.find(member => member.name.toLowerCase() === name.toLowerCase())
     if (demoted != undefined) {
   		demoted.leader = false
-  		leaders = leaders.filter(leader => leader.name.toLowerCase() !== name.toLowerCase())
-  		fs.writeFile("./guilds/lt3.json", JSON.stringify({"lt3":roster}, null, 4), (err) => {
+  		leaders = roster.filter(member => member.leader && (member.name.toLowerCase() !== name.toLowerCase()))
+  		fs.writeFile(rosterLoc, JSON.stringify({"lt3":roster}, null, 4), (err) => {
   				if (err) {
   						console.error(err);
   						return;
   				};
   				message.channel.send(`Removed ${name} from expedition leaders!`)
   		});
-    }
-    else {
+    } else {
       message.channel.send(name + " is not in your guild roster! Please try again");
       return;
     }

--- a/tests/demote.test.js
+++ b/tests/demote.test.js
@@ -1,0 +1,37 @@
+const mock = require('./testHelper'); // all test files should require this
+const demote = require('../commands/demote').demoteCommand;
+jest.mock('fs'); // don't actually write any files
+
+describe("add", () => {
+	beforeEach(() => {
+		mock.mockSendCall.mockClear();
+  });
+	test('Invalid member demote format', () => {
+		let roster = [];
+		demote(mock.newMessage("foo"), roster, './testRoster.json')
+	  expect(mock.mockSendCall).toBeCalledWith("No input. Please use like so: !demote <IGN>");
+	});
+
+	test('Member not in roster', () => {
+		let roster = [];
+		demote(mock.newMessage("!demote buttloaf"), roster, './testRoster.json')
+	  expect(mock.mockSendCall).toBeCalledWith("buttloaf is not in your guild roster! Please try again");
+	});
+
+	test('Successful removed', () => {
+		let roster = [
+			{
+        "id": "Buttloaf#1234",
+        "name": "Buttloaf",
+        "rank": 12,
+        "role": "Bowmaster",
+        "leader": true
+      }
+		];
+		expect(roster.length).toBe(1);
+		expect(roster[0].leader).toBe(true);
+		demote(mock.newMessage("!demote Buttloaf"), roster, './testRoster.json')
+		expect(roster.length).toBe(1);
+		expect(roster[0].leader).toBe(false);
+	});
+});


### PR DESCRIPTION
Some refactoring on demote command. Removed leaders and name from argument list. They can be derived from roster and message respectively. Added default roster location with flexibility to change the written file for testing.